### PR TITLE
Update _distro.py, ignore file 'iredmail-release'

### DIFF
--- a/lib/ansible/module_utils/distro/_distro.py
+++ b/lib/ansible/module_utils/distro/_distro.py
@@ -96,6 +96,7 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
     _OS_RELEASE_BASENAME,
     'system-release',
     'plesk-release',
+    'iredmail-release',
 )
 
 


### PR DESCRIPTION

##### SUMMARY

Ignore file `/etc/iredmail-release` while detecting target OS distribution, it may cause Ansible incorrectly identify target OS distro or release version.

File `/etc/iredmail-release` is generated by iRedMail - a popular open source mail server solution: https://www.iredmail.org/

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`lib/ansible/module_utils/distro/_distro.py`